### PR TITLE
zstage command not found fix

### DIFF
--- a/help.txt
+++ b/help.txt
@@ -10,7 +10,7 @@ To stop a command from executing, hold ctrl + c
 'completequests' -> Completes all unfinished quest stages.
 'completeevents' -> Completes all unfinished quest stages.
 'completezbattles' -> Completes all unfinished zbattles to stage 30.
-'zstage' -> Provides a GUI to complete single Z-Battle stages.
+'zstages' -> Provides a GUI to complete single Z-Battle stages.
 'clash' -> Complete ultimate clash if you have enough UR cards.
 'listevents' -> Prints a list of all currently available events.
 'chooseevents' -> Provides a GUI to sort through events.


### PR DESCRIPTION
This edits help.txt to show zstages instead of zstage since zstage is not a command.